### PR TITLE
Fix plugin declaration for PostCSS 8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const defaultOptions = {
 };
 
 export default propertyLookup;
+propertyLookup.postcss = true;
 
 function propertyLookup(options) {
   const errorContext = {plugin};
@@ -37,59 +38,62 @@ function propertyLookup(options) {
     throw new Error(`Invalid logLevel: ${options.logLevel}`);
   }
 
-  return (root, result) => {
-    root.walkRules((rule) => {
-      eachDecl(rule, (decl) => {
-        if (decl.value.indexOf('@') === -1) {
-          return;
-        }
-        decl.value = decl.value.replace(options.lookupPattern, resolveLookup.bind(this, rule));
-      });
-    });
-
-    function resolveLookup(rule, orig, prop) {
-      const resolvedValue = closest(rule, prop);
-
-      if (!resolvedValue) {
-        if (options.skipUnknown) {
-          return orig;
-        }
-        log(`Unable to find property ${orig} in ${rule.selector}`, rule, result);
-      }
-
-      return resolvedValue;
-    }
-
-    function closest(container, prop) {
-      if (!container) {
-        return '';
-      }
-      let resolvedValue;
-
-      eachDecl(container, (decl) => {
-        if (decl.prop === prop) {
-          resolvedValue = decl.value;
-        }
+  return {
+    postcssPlugin: plugin,
+    Root(root, {result}) {
+      root.walkRules((rule) => {
+        eachDecl(rule, (decl) => {
+          if (decl.value.indexOf('@') === -1) {
+            return;
+          }
+          decl.value = decl.value.replace(options.lookupPattern, resolveLookup.bind(this, rule));
+        });
       });
 
-      if (!resolvedValue) {
-        return closest(container.parent, prop);
-      }
+      function resolveLookup(rule, orig, prop) {
+        const resolvedValue = closest(rule, prop);
 
-      // Ignore a reference to itself
-      // e.g a {color: @color;}
-      if (resolvedValue && resolvedValue.replace('@', '') === prop) {
-        // Lookup on parent the same property
-        return closest(container.parent, prop);
-        // return '';
-      }
+        if (!resolvedValue) {
+          if (options.skipUnknown) {
+            return orig;
+          }
+          log(`Unable to find property ${orig} in ${rule.selector}`, rule, result);
+        }
 
-      if (resolvedValue.indexOf('@') === -1) {
         return resolvedValue;
       }
 
-      return resolvedValue.replace(options.lookupPattern, resolveLookup.bind(this, container));
-    }
+      function closest(container, prop) {
+        if (!container) {
+          return '';
+        }
+        let resolvedValue;
+
+        eachDecl(container, (decl) => {
+          if (decl.prop === prop) {
+            resolvedValue = decl.value;
+          }
+        });
+
+        if (!resolvedValue) {
+          return closest(container.parent, prop);
+        }
+
+        // Ignore a reference to itself
+        // e.g a {color: @color;}
+        if (resolvedValue && resolvedValue.replace('@', '') === prop) {
+          // Lookup on parent the same property
+          return closest(container.parent, prop);
+          // return '';
+        }
+
+        if (resolvedValue.indexOf('@') === -1) {
+          return resolvedValue;
+        }
+
+        return resolvedValue.replace(options.lookupPattern, resolveLookup.bind(this, container));
+      }
+    },
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   },
   "main": "build/index.js",
   "dependencies": {
-    "postcss": "^8.2.4",
     "tcomb": "^3.2.21"
+  },
+  "peerDependencies": {
+    "postcss": "^8.2.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",


### PR DESCRIPTION
Returning a function from the plugin does not work in latest postcss 8, returning an object with the `Root()` function does work.